### PR TITLE
Use simple style on scroll change while using none style

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -85,6 +85,10 @@ browser.runtime.sendMessage({}, function (o) {
         NR.textContent = '>>'
         if (p.settings.displayOption == 'None') {
           S.style.display = 'none'
+          NR.style.display = 'none'
+          U.style.display = 'none'
+          T.style.border = 'none'
+          T.style.background = 'transparent'
         } else if (p.settings.displayOption == 'Always') {
           S.style.display = 'inline'
         } else if (p.settings.displayOption == 'Simple') {


### PR DESCRIPTION
Currently if display option is `None` and you change the speed with shift+scrollwheel it displays the `Always` style with buttons which are not useful in this mode.
With this change it will only display the playback rate like `Simple` style