### PR TITLE
Fixes caption size changing when +/- key pressed

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -317,18 +317,24 @@ browser.runtime.sendMessage({}, function (o) {
           )
         ) {
           changeRate(RATE_ACTIONS.FASTER)
+          e.preventDefault()
+          e.stopPropagation()
         } else if (
           state.settings.slowerKeyCode.match(
             new RegExp('(?:^|,)' + keyPressed + '(?:,|$)')
           )
         ) {
           changeRate(RATE_ACTIONS.SLOWER)
+          e.preventDefault()
+          e.stopPropagation()
         } else if (
           state.settings.resetKeyCode.match(
             new RegExp('(?:^|,)' + keyPressed + '(?:,|$)')
           )
         ) {
           changeRate(RATE_ACTIONS.RESET)
+          e.preventDefault()
+          e.stopPropagation()
         }
 
         return false


### PR DESCRIPTION
Added e.preventDefault() and e.stopPropagation() when handling faster, slower, and reset rate key events to avoid unintended side effects and ensure only the intended action is triggered.

Fixes #32